### PR TITLE
Improve login & preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,15 @@
 
 Android app for sending links to Linkwarden
 
+## Authentication
+
+The app now supports both API key and username/password authentication. When
+adding a Linkwarden instance you can choose your preferred method. If you use
+username and password, the app will create a temporary session token just like
+the official browser extension.
+
+The link form now fetches a small portion of the target page to display a
+preview image and pre-fill the title and description when available.
+
 ![Screenshot_20240823_155131.png](assets%2FScreenshot_20240823_155131.png)
+

--- a/lib/api/linkwarden.dart
+++ b/lib/api/linkwarden.dart
@@ -4,6 +4,7 @@ import 'package:http/http.dart' as http;
 import 'package:send_to_linkwarden/model/tag.dart';
 import 'package:send_to_linkwarden/model/collection.dart';
 import 'package:send_to_linkwarden/model/link.dart';
+import 'package:html/parser.dart' as html;
 
 Future<List<Tag>?> getTags(String token, String baseUrl) async {
   final url = Uri.parse('$baseUrl/api/v1/tags');
@@ -133,4 +134,81 @@ Future<Link?> postLink(String token, String baseUrl, Link link) async {
   }
 
   return Link.fromJson(responseObject['response']);
+}
+
+Future<String> createSession(String baseUrl, String username, String password) async {
+  final url = Uri.parse('$baseUrl/api/v1/session');
+
+  final headers = {
+    HttpHeaders.acceptHeader: 'application/json',
+    HttpHeaders.contentTypeHeader: 'application/json',
+  };
+
+  final body = json.encode({
+    'username': username,
+    'password': password,
+    'sessionName': 'Send To Linkwarden App',
+  });
+
+  final response = await http.post(url, headers: headers, body: body);
+
+  if (response.statusCode < 200 || response.statusCode > 299) {
+    throw HttpException('Failed to login: ${response.statusCode}');
+  }
+
+  final Map<String, dynamic> responseObject = json.decode(response.body);
+
+  if (responseObject['response'] == null || responseObject['response']['token'] == null) {
+    throw const FormatException('Invalid response structure');
+  }
+
+  return responseObject['response']['token'];
+}
+
+Future<Map<String, String?>> fetchPreview(String url) async {
+  final uri = Uri.parse(url);
+  final client = http.Client();
+  try {
+    final request = http.Request('GET', uri)
+      ..headers[HttpHeaders.rangeHeader] = 'bytes=0-102399';
+    final response = await client.send(request).timeout(const Duration(seconds: 1));
+
+    if (response.statusCode < 200 || response.statusCode > 299) {
+      throw HttpException('Failed to load preview: ${response.statusCode}');
+    }
+
+    final contentType = response.headers[HttpHeaders.contentTypeHeader];
+    if (contentType == null || !contentType.contains('text/html')) {
+      return {};
+    }
+
+    final bytes = <int>[];
+    await for (final chunk in response.stream) {
+      bytes.addAll(chunk);
+      if (bytes.length > 102400) {
+        bytes.removeRange(102400, bytes.length);
+        break;
+      }
+    }
+
+    final document = html.parse(utf8.decode(bytes));
+    String? title = document.querySelector('title')?.text;
+    title ??= document.querySelector('meta[property="og:title"]')?.attributes['content'];
+    title ??= document.querySelector('meta[name="twitter:title"]')?.attributes['content'];
+
+    String? description = document.querySelector('meta[name="description"]')?.attributes['content'];
+    description ??= document.querySelector('meta[property="og:description"]')?.attributes['content'];
+    description ??= document.querySelector('meta[name="twitter:description"]')?.attributes['content'];
+
+    String? image = document.querySelector('meta[property="og:image"]')?.attributes['content'];
+    image ??= document.querySelector('meta[name="twitter:image"]')?.attributes['content'];
+
+    return {
+      'title': title,
+      'description': description,
+      'image': image,
+    };
+  } finally {
+    client.close();
+  }
 }

--- a/lib/view/add_edit_user_instance_view.dart
+++ b/lib/view/add_edit_user_instance_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:send_to_linkwarden/model/user_instance.dart';
+import 'package:send_to_linkwarden/api/linkwarden.dart';
 
 class AddEditUserInstanceViewArguments {
   final UserInstance? userInstance;
@@ -21,6 +22,7 @@ class AddEditUserInstanceView extends StatefulWidget {
 class _AddEditUserInstanceViewState extends State<AddEditUserInstanceView> {
   GlobalKey<FormState> formState = GlobalKey<FormState>();
   late UserInstance userInstance;
+  String _method = 'apiKey';
 
   @override
   void initState() {
@@ -43,9 +45,10 @@ class _AddEditUserInstanceViewState extends State<AddEditUserInstanceView> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
               _instanceUrlInput(context),
-              _apiTokenInput(context),
-              // _usernameEmailInput(context),
-              // _passwordInput(context),
+              _methodSelection(context),
+              if (_method == 'apiKey') _apiTokenInput(context),
+              if (_method == 'username') _usernameEmailInput(context),
+              if (_method == 'username') _passwordInput(context),
               _actionButtons(context),
             ],
           ),
@@ -97,6 +100,24 @@ class _AddEditUserInstanceViewState extends State<AddEditUserInstanceView> {
     );
   }
 
+  Widget _methodSelection(BuildContext context) {
+    return DropdownButtonFormField(
+      decoration: const InputDecoration(
+        labelText: 'Authentication Method',
+      ),
+      value: _method,
+      items: const [
+        DropdownMenuItem(value: 'apiKey', child: Text('API Key')),
+        DropdownMenuItem(value: 'username', child: Text('Username/Password')),
+      ],
+      onChanged: (value) {
+        setState(() {
+          _method = value ?? 'apiKey';
+        });
+      },
+    );
+  }
+
   final TextEditingController passwordTextController = TextEditingController();
   Widget _passwordInput(BuildContext context) {
     return TextFormField(
@@ -140,16 +161,34 @@ class _AddEditUserInstanceViewState extends State<AddEditUserInstanceView> {
         TextButton(onPressed: () {
           setState(_loadValues);
         }, child: const Text("Reset")),
-        TextButton(onPressed: () {
+        TextButton(onPressed: () async {
           if (formState.currentState!.validate()) {
             ScaffoldMessenger.of(context).showSnackBar(
               const SnackBar(content: Text('Processing Data')),
             );
+            String? token = apiTokenTextController.text;
+            if (_method == 'username') {
+              try {
+                token = await createSession(
+                  urlTextController.text,
+                  usernameTextController.text,
+                  passwordTextController.text,
+                );
+              } catch (e) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Login failed: ${e.toString()}')),
+                  );
+                }
+                return;
+              }
+            }
+
             Navigator.pop(context, userInstance
               ..user = usernameTextController.text
               ..server = urlTextController.text
-              ..password = passwordTextController.text
-              ..apiToken = apiTokenTextController.text
+              ..password = _method == 'username' ? passwordTextController.text : null
+              ..apiToken = token
             );
           } else {
             ScaffoldMessenger.of(context).showSnackBar(
@@ -166,5 +205,10 @@ class _AddEditUserInstanceViewState extends State<AddEditUserInstanceView> {
     urlTextController.text = userInstance.server ?? "";
     passwordTextController.text = userInstance.password ?? "";
     apiTokenTextController.text = userInstance.apiToken ?? "";
+    if (userInstance.apiToken != null && userInstance.apiToken!.isNotEmpty) {
+      _method = 'apiKey';
+    } else {
+      _method = 'username';
+    }
   }
 }

--- a/lib/view/add_link_view.dart
+++ b/lib/view/add_link_view.dart
@@ -41,6 +41,23 @@ class _AddLinkViewState extends State<AddLinkView> {
   TextEditingController nameTextController = TextEditingController();
   TextEditingController descriptionTextController = TextEditingController();
   TextEditingController linkTextController = TextEditingController();
+  String? previewImageUrl;
+
+  Future<void> _fetchPreview() async {
+    try {
+      final preview = await fetchPreview(linkTextController.text);
+      if (preview['title'] != null && nameTextController.text.isEmpty) {
+        nameTextController.text = preview['title']!;
+      }
+      if (preview['description'] != null &&
+          descriptionTextController.text.isEmpty) {
+        descriptionTextController.text = preview['description']!;
+      }
+      setState(() {
+        previewImageUrl = preview['image'];
+      });
+    } catch (_) {}
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -61,6 +78,7 @@ class _AddLinkViewState extends State<AddLinkView> {
               _userAndInstanceSelection(context),
               _collectionSelection(context),
               _linkInput(context),
+              _previewCard(),
               ..._tagsSelection(context),
               _nameInput(context),
               _descriptionInput(context),
@@ -79,6 +97,7 @@ class _AddLinkViewState extends State<AddLinkView> {
     collectionsStream = collectionsReplayer.subscribe(initialKey: null);
     if (widget.arguments?.link != null) {
       linkTextController.text = widget.arguments!.link!;
+      _fetchPreview();
     }
     if (widget.arguments?.name != null) {
       nameTextController.text = widget.arguments!.name!;
@@ -164,6 +183,7 @@ class _AddLinkViewState extends State<AddLinkView> {
     linkTextController.text = "";
     nameTextController.text = "";
     descriptionTextController.text = "";
+    previewImageUrl = null;
     setState(() {
       tags = [];
     });
@@ -448,8 +468,14 @@ class _AddLinkViewState extends State<AddLinkView> {
 
   Widget _linkInput(BuildContext context) {
     return TextFormField(
-      decoration: const InputDecoration(
-          labelText: "Link", helper: Text("e.g. http://example.com/")),
+      decoration: InputDecoration(
+          labelText: "Link",
+          helper: const Text("e.g. http://example.com/"),
+          suffixIcon: IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _fetchPreview,
+          )),
+      onEditingComplete: _fetchPreview,
       validator: (value) {
         if (value == null) {
           return "Please enter a value";
@@ -483,6 +509,16 @@ class _AddLinkViewState extends State<AddLinkView> {
           labelText: "Description", helper: Text("Notes, thoughts, etc.")),
       maxLines: null,
       controller: descriptionTextController,
+    );
+  }
+
+  Widget _previewCard() {
+    if (previewImageUrl == null) {
+      return const SizedBox.shrink();
+    }
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Image.network(previewImageUrl!, height: 100),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   flutter_colorpicker: ^1.1.0
   uuid: ^3.0.5
   http: ^1.2.2
+  html: ^0.15.6
   json_annotation: ^4.9.0
   flutter_secure_storage: ^9.2.2
   receive_sharing_intent: ^1.8.0


### PR DESCRIPTION
## Summary
- support API key or username/password login
- fetch preview image for a link
- show preview image and fill title/description automatically
- document authentication options
- limit preview download to 100KB and parse Twitter cards

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68410151886c832f80394a09ca7c6c6a