### PR TITLE
Enhance endpoint management with drawer

### DIFF
--- a/lib/state/user_instance_replayer.dart
+++ b/lib/state/user_instance_replayer.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:send_to_linkwarden/core/pub_sub_replay.dart';
 import 'package:send_to_linkwarden/integrations/secure_storage.dart';
 import 'package:send_to_linkwarden/model/user_instance.dart';
+import 'package:send_to_linkwarden/state/default_user_instance.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 PubSubReplay<List<UserInstance>> userInstanceValueReplayer = PubSubReplay(onNoLastMessage: loadUserInstances);
@@ -39,4 +40,15 @@ void upsertUserInstance(UserInstance userInstances) async {
   }
   userInstanceValueReplayer.publish(current);
   _saveUserInstances(current);
+}
+
+Future<void> deleteUserInstance(UserInstance instance) async {
+  var sub = userInstanceValueReplayer.subscribe();
+  List<UserInstance> current = [...await sub.first];
+  current.removeWhere((e) => e.id == instance.id);
+  userInstanceValueReplayer.publish(current);
+  _saveUserInstances(current);
+  if ((await loadDefaultUserInstance()) == instance.id) {
+    await setDefaultUserInstance(null);
+  }
 }

--- a/lib/view/add_link_view.dart
+++ b/lib/view/add_link_view.dart
@@ -12,6 +12,7 @@ import 'package:send_to_linkwarden/state/default_user_instance.dart';
 import 'package:send_to_linkwarden/state/tags_replayer.dart';
 import 'package:send_to_linkwarden/state/user_instance_replayer.dart';
 import 'package:send_to_linkwarden/view/select_tags_view.dart';
+import 'package:send_to_linkwarden/view/manage_user_instances_drawer.dart';
 
 import 'add_edit_user_instance_view.dart';
 
@@ -62,6 +63,7 @@ class _AddLinkViewState extends State<AddLinkView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      drawer: const ManageUserInstancesDrawer(),
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: const Text("Add Bookmark - Send To Linkwarden"),

--- a/lib/view/manage_user_instances_drawer.dart
+++ b/lib/view/manage_user_instances_drawer.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:send_to_linkwarden/model/user_instance.dart';
+import 'package:send_to_linkwarden/state/user_instance_replayer.dart';
+import 'package:send_to_linkwarden/view/add_edit_user_instance_view.dart';
+
+class ManageUserInstancesDrawer extends StatelessWidget {
+  const ManageUserInstancesDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: StreamBuilder(
+        stream: userInstanceValueReplayer.subscribe(),
+        builder: (context, AsyncSnapshot<List<UserInstance>> snapshot) {
+          if (snapshot.hasError) {
+            return Center(
+              child: Text('Error loading instances: ${snapshot.error}'),
+            );
+          }
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          var instances = snapshot.data ?? [];
+          return ListView(
+            padding: EdgeInsets.zero,
+            children: [
+              const DrawerHeader(
+                child: Text('Manage Linkwarden Instances'),
+              ),
+              for (UserInstance instance in instances)
+                ListTile(
+                  title: Text(instance.server ?? 'Unknown URL'),
+                  subtitle: Text(instance.user ?? ''),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.edit),
+                        onPressed: () async {
+                          Navigator.pop(context);
+                          var result = await Navigator.pushNamed(
+                            context,
+                            'userInstance/newEdit',
+                            arguments: AddEditUserInstanceViewArguments(userInstance: instance),
+                          );
+                          if (result is UserInstance) {
+                            upsertUserInstance(result);
+                          }
+                        },
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.delete),
+                        onPressed: () async {
+                          bool? confirm = await showDialog<bool>(
+                            context: context,
+                            builder: (context) => AlertDialog(
+                              title: const Text('Delete Instance'),
+                              content: const Text('Are you sure you want to delete this instance?'),
+                              actions: [
+                                TextButton(
+                                  onPressed: () => Navigator.pop(context, false),
+                                  child: const Text('Cancel'),
+                                ),
+                                TextButton(
+                                  onPressed: () => Navigator.pop(context, true),
+                                  child: const Text('Delete'),
+                                ),
+                              ],
+                            ),
+                          );
+                          if (confirm == true) {
+                            deleteUserInstance(instance);
+                          }
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+              ListTile(
+                leading: const Icon(Icons.add),
+                title: const Text('Add Instance'),
+                onTap: () async {
+                  Navigator.pop(context);
+                  var result = await Navigator.pushNamed(
+                    context,
+                    'userInstance/newEdit',
+                    arguments: const AddEditUserInstanceViewArguments(),
+                  );
+                  if (result is UserInstance) {
+                    upsertUserInstance(result);
+                  }
+                },
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- allow removing user instances and clear default
- add drawer to manage existing endpoints
- wire drawer into AddLinkView

## Testing
- `dart --version` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684106f1b930832f87a6aada43ca5a1c