### PR TITLE
Add instance reordering and default handling

### DIFF
--- a/lib/state/user_instance_replayer.dart
+++ b/lib/state/user_instance_replayer.dart
@@ -24,6 +24,14 @@ void _saveUserInstances(List<UserInstance> userInstances) async {
   await storage.write(key: "UserInstancesV1", value: jsonEncode(userInstances));
 }
 
+void _ensureDefaultIsFirst(List<UserInstance> userInstances) {
+  if (userInstances.isNotEmpty) {
+    setDefaultUserInstance(userInstances.first.id);
+  } else {
+    setDefaultUserInstance(null);
+  }
+}
+
 Future<UserInstance?> getUserInstanceById(String? id) async {
   var sub = userInstanceValueReplayer.subscribe();
   return (await sub.first).firstWhere((e) => e.id == id);
@@ -40,6 +48,7 @@ void upsertUserInstance(UserInstance userInstances) async {
   }
   userInstanceValueReplayer.publish(current);
   _saveUserInstances(current);
+  _ensureDefaultIsFirst(current);
 }
 
 Future<void> deleteUserInstance(UserInstance instance) async {
@@ -51,4 +60,18 @@ Future<void> deleteUserInstance(UserInstance instance) async {
   if ((await loadDefaultUserInstance()) == instance.id) {
     await setDefaultUserInstance(null);
   }
+  _ensureDefaultIsFirst(current);
+}
+
+void reorderUserInstances(int oldIndex, int newIndex) async {
+  var sub = userInstanceValueReplayer.subscribe();
+  List<UserInstance> current = [...await sub.first];
+  if (newIndex > oldIndex) {
+    newIndex -= 1;
+  }
+  final item = current.removeAt(oldIndex);
+  current.insert(newIndex, item);
+  userInstanceValueReplayer.publish(current);
+  _saveUserInstances(current);
+  _ensureDefaultIsFirst(current);
 }

--- a/lib/view/add_link_view.dart
+++ b/lib/view/add_link_view.dart
@@ -129,6 +129,7 @@ class _AddLinkViewState extends State<AddLinkView> {
     if (widget.arguments?.description != null) {
       descriptionTextController.text = widget.arguments!.description!;
     }
+    WidgetsBinding.instance.addPostFrameCallback((_) => _promptForInstanceIfNeeded());
   }
 
   @override
@@ -138,6 +139,21 @@ class _AddLinkViewState extends State<AddLinkView> {
 
   void _darkMode() async {
     setDarkMode(!darkModeNotifier.value);
+  }
+
+  Future<void> _promptForInstanceIfNeeded() async {
+    var list = await userInstanceValueReplayer.subscribe().first;
+    if (list.isEmpty && context.mounted) {
+      var result = await Navigator.pushNamed(
+        context,
+        'userInstance/newEdit',
+        arguments: const AddEditUserInstanceViewArguments(),
+      );
+      if (result is UserInstance) {
+        upsertUserInstance(result);
+        _selectNewUserInstance(result, makeDefault: true);
+      }
+    }
   }
 
   Widget _submitButton(BuildContext context) {
@@ -246,19 +262,22 @@ class _AddLinkViewState extends State<AddLinkView> {
             if (list.connectionState == ConnectionState.waiting) {
               return const Center(child: CircularProgressIndicator());
             }
-            // Should be a better way of doing this by combining the streams.
-            if (!selectedUserInstanceSet && defaultValueLoaded.data != null && selectedUserInstance == null) {
+            if (!selectedUserInstanceSet && list.connectionState == ConnectionState.active) {
               WidgetsBinding.instance.addPostFrameCallback((_) {
                 setState(() {
                   selectedUserInstanceSet = true;
                 });
-                _selectNewUserInstance(list.requireData.where((each) => each.id == defaultValueLoaded.requireData).firstOrNull, makeDefault: false);
+                UserInstance? chosen;
+                if (defaultValueLoaded.data != null) {
+                  chosen = list.requireData.firstWhere(
+                    (each) => each.id == defaultValueLoaded.requireData,
+                    orElse: () => list.requireData.isNotEmpty ? list.requireData.first : null,
+                  );
+                } else if (list.requireData.isNotEmpty) {
+                  chosen = list.requireData.first;
+                }
+                _selectNewUserInstance(chosen, makeDefault: false);
               });
-            }
-            if (!selectedUserInstanceSet && list.connectionState == ConnectionState.active) {
-              WidgetsBinding.instance.addPostFrameCallback((_) => setState(() {
-                selectedUserInstanceSet = true;
-              }));
             }
             return Flex(
               direction: Axis.horizontal,

--- a/lib/view/manage_user_instances_view.dart
+++ b/lib/view/manage_user_instances_view.dart
@@ -3,9 +3,14 @@ import 'package:send_to_linkwarden/model/user_instance.dart';
 import 'package:send_to_linkwarden/state/user_instance_replayer.dart';
 import 'package:send_to_linkwarden/view/add_edit_user_instance_view.dart';
 
-class ManageUserInstancesView extends StatelessWidget {
+class ManageUserInstancesView extends StatefulWidget {
   const ManageUserInstancesView({super.key});
 
+  @override
+  State<ManageUserInstancesView> createState() => _ManageUserInstancesViewState();
+}
+
+class _ManageUserInstancesViewState extends State<ManageUserInstancesView> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -43,63 +48,72 @@ class ManageUserInstancesView extends StatelessWidget {
                       return const Center(child: CircularProgressIndicator());
                     }
                     var instances = snapshot.data ?? [];
-                    return ListView(
-                      shrinkWrap: true,
+                    return Column(
                       children: [
-                        for (UserInstance instance in instances)
-                          ListTile(
-                            title: Text(instance.server ?? 'Unknown URL'),
-                            subtitle: Text(instance.user ?? ''),
-                            trailing: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                IconButton(
-                                  icon: const Icon(Icons.edit),
-                                  onPressed: () async {
-                                    var result = await Navigator.pushNamed(
-                                      context,
-                                      'userInstance/newEdit',
-                                      arguments:
-                                          AddEditUserInstanceViewArguments(
-                                              userInstance: instance),
-                                    );
-                                    if (result is UserInstance) {
-                                      upsertUserInstance(result);
-                                    }
-                                  },
-                                ),
-                                IconButton(
-                                  icon: const Icon(Icons.delete),
-                                  onPressed: () async {
-                                    bool? confirm = await showDialog<bool>(
-                                      context: context,
-                                      builder: (context) => AlertDialog(
-                                        title: const Text('Delete Instance'),
-                                        content: const Text(
-                                            'Are you sure you want to delete this instance?'),
-                                        actions: [
-                                          TextButton(
-                                            onPressed: () =>
-                                                Navigator.pop(context, false),
-                                            child: const Text('Cancel'),
+                        ReorderableListView(
+                          shrinkWrap: true,
+                          onReorder: (oldIndex, newIndex) {
+                            reorderUserInstances(oldIndex, newIndex);
+                          },
+                          children: [
+                            for (UserInstance instance in instances)
+                              ListTile(
+                                key: ValueKey(instance.id),
+                                title: Text(instance.server ?? 'Unknown URL'),
+                                subtitle: Text(instance.user ?? ''),
+                                trailing: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    IconButton(
+                                      icon: const Icon(Icons.edit),
+                                      onPressed: () async {
+                                        var result = await Navigator.pushNamed(
+                                          context,
+                                          'userInstance/newEdit',
+                                          arguments:
+                                              AddEditUserInstanceViewArguments(
+                                                  userInstance: instance),
+                                        );
+                                        if (result is UserInstance) {
+                                          upsertUserInstance(result);
+                                        }
+                                      },
+                                    ),
+                                    IconButton(
+                                      icon: const Icon(Icons.delete),
+                                      onPressed: () async {
+                                        bool? confirm = await showDialog<bool>(
+                                          context: context,
+                                          builder: (context) => AlertDialog(
+                                            title: const Text('Delete Instance'),
+                                            content: const Text(
+                                                'Are you sure you want to delete this instance?'),
+                                            actions: [
+                                              TextButton(
+                                                onPressed: () =>
+                                                    Navigator.pop(context, false),
+                                                child: const Text('Cancel'),
+                                              ),
+                                              TextButton(
+                                                onPressed: () =>
+                                                    Navigator.pop(context, true),
+                                                child: const Text('Delete'),
+                                              ),
+                                            ],
                                           ),
-                                          TextButton(
-                                            onPressed: () =>
-                                                Navigator.pop(context, true),
-                                            child: const Text('Delete'),
-                                          ),
-                                        ],
-                                      ),
-                                    );
-                                    if (confirm == true) {
-                                      deleteUserInstance(instance);
-                                    }
-                                  },
+                                        );
+                                        if (confirm == true) {
+                                          deleteUserInstance(instance);
+                                        }
+                                      },
+                                    ),
+                                  ],
                                 ),
-                              ],
-                            ),
-                          ),
+                              ),
+                          ],
+                        ),
                         ListTile(
+                          key: const ValueKey('add'),
                           leading: const Icon(Icons.add),
                           title: const Text('Add Instance'),
                           onTap: () async {


### PR DESCRIPTION
## Summary
- keep default instance synced with the first item
- add reorderUserInstances helper
- allow rearranging instances in management view
- prompt for instance when none exist and remember shared link
- automatically select the first instance when no default is stored

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684152ecaf58832fb8ed1f68b8573df7