### PR TITLE
Fix uuid version conflict

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
     sdk: flutter
   shared_preferences: ^2.5.3
   flutter_colorpicker: ^1.1.0
-  uuid: ^4.5.1
+  uuid: ^3.0.7
   http: ^1.4.0
   html: ^0.15.6
   json_annotation: ^4.9.0


### PR DESCRIPTION
## Summary
- resolve dependency conflict with `fastforge` by downgrading `uuid`

## Testing
- `dart pub get` *(fails: Flutter SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_68418e817a94832fa24754dc095af6c0