### PR TITLE
Update package name for v2 release

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -30,7 +30,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    namespace = "com.arran4.send_to_linkwarden"
+    namespace = "com.arran4.send_to_linkwarden_v2"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -41,7 +41,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.arran4.send_to_linkwarden"
+        applicationId = "com.arran4.send_to_linkwarden_v2"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="com.arran4.send_to_linkwarden_v2" xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="com.arran4.send_to_linkwarden_v2" xmlns:android="http://schemas.android.com/apk/res/android">
     <application
         android:label="Send To Linkwarden"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/com/arran4/send_to_linkwarden_v2/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/arran4/send_to_linkwarden_v2/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.arran4.send_to_linkwarden
+package com.arran4.send_to_linkwarden_v2
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -1,4 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest package="com.arran4.send_to_linkwarden_v2" xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- The INTERNET permission is required for development. Specifically,
          the Flutter tool needs it to communicate with the running application
          to allow setting breakpoints, to provide hot reload, etc.

--- a/distribute_options.yaml
+++ b/distribute_options.yaml
@@ -79,7 +79,7 @@ releases:
         publish:
           target: playstore
           args:
-            package-name: com.arran4.send_to_linkwarden
+            package-name: com.arran4.send_to_linkwarden_v2
             track: production
       - name: android-apk
         package:


### PR DESCRIPTION
## Summary
- rename Android package to `com.arran4.send_to_linkwarden_v2`
- move `MainActivity.kt` to match new path
- set package attribute in all AndroidManifests
- update package name for Play Store distribution

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684197be5a08832fbf0b1724020e518b