### PR TITLE
Add Flutter testing instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Instructions
+
+## Testing
+
+All automated tests are run using Flutter. To install Flutter:
+
+1. Download `https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_3.32.4-stable.tar.xz`.
+2. Extract the archive to a convenient location (for example `~/.flutter`).
+3. Add the extracted `bin` directory to the `PATH` environment variable.
+
+After installing, run `flutter doctor` to verify the setup and use `flutter test` to execute the test suite.


### PR DESCRIPTION
## Summary
- instruct agents to use Flutter for automated tests
- outline how to install Flutter from the tarball

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855078df634832fb2c381ede9b9d37e