### PR TITLE
Use self-hosted runner for Linux workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
   linux:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
@@ -147,7 +147,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
   release:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs:
       - windows
       - linux

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
## Summary
- update `runs-on` for Linux jobs to use the self-hosted runner

## Testing
- `flutter doctor -v`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6867c0069798832faa55250b64255b73