### PR TITLE
Use GitHub-hosted runners

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
   linux:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1
@@ -147,7 +147,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
   release:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs:
       - windows
       - linux

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dart-lang/setup-dart@v1


### PR DESCRIPTION
## Summary
- run tests and Linux release on `ubuntu-latest`
- run final release step on `ubuntu-latest`

## Testing
- `flutter doctor -v`
- `flutter --version`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_686dde7272c8832fb4a09ad459505245