### PR TITLE
Refine tag subscription disposal

### DIFF
--- a/lib/view/select_tags_view.dart
+++ b/lib/view/select_tags_view.dart
@@ -96,7 +96,11 @@ class _SelectTagsViewState extends State<SelectTagsView> {
 
   @override
   void dispose() {
-    tagSubscription?.cancel();
+    final subscription = tagSubscription;
+    tagSubscription = null;
+    if (subscription != null) {
+      unawaited(subscription.cancel());
+    }
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- store the active tag subscription in a local variable during disposal
- clear the field before cancelling and wrap the cancel future in `unawaited`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db6079f718832f91178fbdbeacc461