### PR TITLE
Wrap replayer subscription with unawaited

### DIFF
--- a/lib/view/add_edit_user_instance_view.dart
+++ b/lib/view/add_edit_user_instance_view.dart
@@ -1,3 +1,5 @@
+import 'dart:async' show unawaited;
+
 import 'package:flutter/material.dart';
 import 'package:send_to_linkwarden/model/user_instance.dart';
 import 'package:send_to_linkwarden/api/linkwarden.dart';
@@ -300,10 +302,13 @@ class _AddEditUserInstanceViewState extends State<AddEditUserInstanceView> {
       _method = 'username';
     }
     // Determine if we are editing an existing instance based on stored list
-    userInstanceValueReplayer.subscribe().first.then((list) {
+    unawaited(userInstanceValueReplayer.subscribe().first.then((list) {
+      if (!mounted) {
+        return;
+      }
       setState(() {
         _editingExisting = list.any((e) => e.id == userInstance.id);
       });
-    });
+    }));
   }
 }


### PR DESCRIPTION
## Summary
- add the dart async unawaited import to the add/edit user instance view
- wrap the value replay subscription in unawaited and guard setState behind mounted

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db607ad388832f8f9f698f556eedf9