### PR TITLE
Wrap default user instance updates with unawaited

### DIFF
--- a/lib/state/user_instance_replayer.dart
+++ b/lib/state/user_instance_replayer.dart
@@ -1,3 +1,4 @@
+import 'dart:async' show unawaited;
 import 'dart:convert';
 
 import 'package:send_to_linkwarden/core/pub_sub_replay.dart';
@@ -26,9 +27,9 @@ void _saveUserInstances(List<UserInstance> userInstances) async {
 
 void _ensureDefaultIsFirst(List<UserInstance> userInstances) {
   if (userInstances.isNotEmpty) {
-    setDefaultUserInstance(userInstances.first.id);
+    unawaited(setDefaultUserInstance(userInstances.first.id));
   } else {
-    setDefaultUserInstance(null);
+    unawaited(setDefaultUserInstance(null));
   }
 }
 


### PR DESCRIPTION
## Summary
- import dart:async unawaited helper in the user instance replayer
- wrap default user instance setter calls with unawaited to express fire-and-forget behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db607c5a14832fadeef46cb87fa1e7