### PR TITLE
Await user instance deletion with feedback

### DIFF
--- a/lib/view/manage_user_instances_view.dart
+++ b/lib/view/manage_user_instances_view.dart
@@ -7,7 +7,8 @@ class ManageUserInstancesView extends StatefulWidget {
   const ManageUserInstancesView({super.key});
 
   @override
-  State<ManageUserInstancesView> createState() => _ManageUserInstancesViewState();
+  State<ManageUserInstancesView> createState() =>
+      _ManageUserInstancesViewState();
 }
 
 class _ManageUserInstancesViewState extends State<ManageUserInstancesView> {
@@ -30,8 +31,8 @@ class _ManageUserInstancesViewState extends State<ManageUserInstancesView> {
             padding: const EdgeInsets.all(16.0),
             child: Card(
               elevation: 4,
-              shape:
-                  RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12)),
               child: Padding(
                 padding: const EdgeInsets.all(16.0),
                 child: StreamBuilder(
@@ -85,25 +86,48 @@ class _ManageUserInstancesViewState extends State<ManageUserInstancesView> {
                                         bool? confirm = await showDialog<bool>(
                                           context: context,
                                           builder: (context) => AlertDialog(
-                                            title: const Text('Delete Instance'),
+                                            title:
+                                                const Text('Delete Instance'),
                                             content: const Text(
                                                 'Are you sure you want to delete this instance?'),
                                             actions: [
                                               TextButton(
-                                                onPressed: () =>
-                                                    Navigator.pop(context, false),
+                                                onPressed: () => Navigator.pop(
+                                                    context, false),
                                                 child: const Text('Cancel'),
                                               ),
                                               TextButton(
-                                                onPressed: () =>
-                                                    Navigator.pop(context, true),
+                                                onPressed: () => Navigator.pop(
+                                                    context, true),
                                                 child: const Text('Delete'),
                                               ),
                                             ],
                                           ),
                                         );
                                         if (confirm == true) {
-                                          deleteUserInstance(instance);
+                                          try {
+                                            await deleteUserInstance(instance);
+                                            if (mounted) {
+                                              ScaffoldMessenger.of(context)
+                                                  .showSnackBar(
+                                                const SnackBar(
+                                                  content: Text(
+                                                      'Instance deleted successfully.'),
+                                                ),
+                                              );
+                                            }
+                                          } catch (error) {
+                                            if (mounted) {
+                                              ScaffoldMessenger.of(context)
+                                                  .showSnackBar(
+                                                SnackBar(
+                                                  content: Text(
+                                                    'Failed to delete instance: $error',
+                                                  ),
+                                                ),
+                                              );
+                                            }
+                                          }
                                         }
                                       },
                                     ),


### PR DESCRIPTION
## Summary
- await user instance deletion calls in the manage view
- add snackbar feedback for success and failure when deleting an instance

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db607d805c832f9fe395c0c0649100